### PR TITLE
Feat/request-id-injection: Inject request Id to the logger on every new request

### DIFF
--- a/server/api/cronJob/aggregateJob.js
+++ b/server/api/cronJob/aggregateJob.js
@@ -9,7 +9,6 @@ import {
     getTotalOrderAmtForDate,
     getTotalOrderAmtByDateForCategory
 } from '../orders';
-import log from 'utils/logger';
 
 export const aggregateCheck = async () => {
     try {

--- a/server/api/requestGenerators.js
+++ b/server/api/requestGenerators.js
@@ -72,7 +72,9 @@ export const generateCreateUserRequest = (router, model, validator) => {
                 password: password
             });
             req.body.authId = authUser.user_id;
-            const user = await createUser(model, req.body);
+            let user = await createUser(model, req.body);
+            user = user._doc;
+            delete user.authId;
             return apiSuccess(res, user);
         } catch (err) {
             return apiFailure(res, err.message);

--- a/server/api/tests/utils.test.js
+++ b/server/api/tests/utils.test.js
@@ -6,8 +6,10 @@ import {
     fetchItems,
     updateItem
 } from '../utils';
+import log from 'utils/logger';
 
 describe('utils tests', () => {
+    const spy = jest.spyOn(log, 'info');
     describe('createItem tests', () => {
         it('should createItem successfully create and return item', async () => {
             const model = {
@@ -27,6 +29,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => createItem(model)).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 
@@ -76,6 +79,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => fetchItems(model, {})).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 
@@ -98,6 +102,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => fetchItem(model)).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 
@@ -123,6 +128,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => updateItem(model)).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 
@@ -146,6 +152,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => deleteItem(model)).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 
@@ -168,6 +175,7 @@ describe('utils tests', () => {
                 })
             };
             expect(() => createUser(model)).rejects.toThrow(error);
+            expect(spy).toHaveBeenCalledWith({ err: error });
         });
     });
 });

--- a/server/api/users/tests/index.test.js
+++ b/server/api/users/tests/index.test.js
@@ -27,7 +27,9 @@ describe('User tests', () => {
     });
 
     it('should call the create user api', async () => {
-        jest.spyOn(daos, 'createUser').mockResolvedValueOnce(mockUser);
+        jest.spyOn(daos, 'createUser').mockResolvedValueOnce({
+            _doc: mockUser
+        });
         const res = await supertest(app)
             .post('/users')
             .set('Accept', 'application/json')
@@ -42,7 +44,6 @@ describe('User tests', () => {
     });
 
     it('should  call the create user api and throw error', async () => {
-        jest.spyOn(daos, 'createUser').mockResolvedValueOnce(mockUser);
         const res = await supertest(app)
             .post('/users')
             .set('Accept', 'application/json')

--- a/server/api/users/tests/index.test.js
+++ b/server/api/users/tests/index.test.js
@@ -43,7 +43,8 @@ describe('User tests', () => {
         expect(res.body.data).toEqual(mockUser);
     });
 
-    it('should  call the create user api and throw error', async () => {
+    it('should call the create user api and throw error', async () => {
+        jest.spyOn(daos, 'createUser').mockResolvedValueOnce(mockUser);
         const res = await supertest(app)
             .post('/users')
             .set('Accept', 'application/json')
@@ -52,7 +53,7 @@ describe('User tests', () => {
         expect(JSON.stringify(res.body.error)).toContain('must be present');
     });
 
-    it('should  call the create user  and throw error', async () => {
+    it('should call the create user and throw error', async () => {
         jest.spyOn(daos, 'createUser').mockRejectedValueOnce(
             new Error('User already exists!')
         );

--- a/server/api/utils.js
+++ b/server/api/utils.js
@@ -1,4 +1,3 @@
-import log from 'utils/logger';
 export const createItem = async (model, args) => {
     try {
         return model.create(args);

--- a/server/daos/tests/order.test.js
+++ b/server/daos/tests/order.test.js
@@ -65,7 +65,7 @@ describe('Order daos tests', () => {
         it('should return the date of the first order', async () => {
             mockingoose(model).toReturn({}, 'findOne');
             const res = await earliestCreatedDate();
-            expect(res).toBe(moment().format('YYYY-MM-DD'));
+            expect(res).toBe(moment.utc().format('YYYY-MM-DD'));
         });
         it('should throw an error if an error is thrown from db', async () => {
             mockingoose(model).toReturn(mockError, 'findOne');

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,7 @@ import apis from 'api';
 import { list } from 'server/routeLister';
 import { isTestEnv } from 'utils';
 import { initQueues } from 'utils/queue';
+import injectRequestId from 'middlewares/injectRequestId';
 
 /**
  * Connect to database
@@ -22,11 +23,11 @@ app.use(responseTime());
 app.set('port', process.env.PORT || 9000);
 app.use(helmet());
 app.use(cors());
+app.use(injectRequestId());
 app.use(express.json());
 // get information from html forms
 app.use(bodyParser.json({ limit: '10mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
-
 // setup database
 apis(app);
 /* istanbul ignore next */

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,7 @@ app.use(express.json());
 // get information from html forms
 app.use(bodyParser.json({ limit: '10mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
+
 // setup database
 apis(app);
 /* istanbul ignore next */

--- a/server/middlewares/injectRequestId/index.js
+++ b/server/middlewares/injectRequestId/index.js
@@ -1,14 +1,14 @@
 import { v4 as uuid } from 'uuid';
 import log from 'utils/logger';
 
-function InjectRequestId(options, requestId) {
+function RequestIdInjectedLogger(options, requestId) {
     this.log = options.log.child({ requestId });
 }
 
 const injectRequestId = () => (_request, _response, next) => {
     const requestId = uuid();
-    const requestLogger = new InjectRequestId({ log }, requestId);
-    global.log = requestLogger.log;
+    const logger = new RequestIdInjectedLogger({ log }, requestId);
+    global.log = logger.log;
     next();
 };
 

--- a/server/middlewares/injectRequestId/index.js
+++ b/server/middlewares/injectRequestId/index.js
@@ -1,0 +1,15 @@
+import { v4 as uuid } from 'uuid';
+import log from 'utils/logger';
+
+function InjectRequestId(options, requestId) {
+    this.log = options.log.child({ requestId });
+}
+
+const injectRequestId = () => (_request, _response, next) => {
+    const requestId = uuid();
+    const requestLogger = new InjectRequestId({ log }, requestId);
+    global.log = requestLogger.log;
+    next();
+};
+
+module.exports = injectRequestId;

--- a/server/utils/apiUtils.js
+++ b/server/utils/apiUtils.js
@@ -1,5 +1,4 @@
 import { validationResult } from 'express-validator';
-import log from 'utils/logger';
 export const apiSuccess = (res, data) => {
     log.info('apiSuccess', { data });
     return res.send({ data }).status(200);


### PR DESCRIPTION
### Ticket Link

---

### Related Links

---

### Description

- Removed the authId from the user that is returned during signup
- Inject new RequestId to logger for every request made for better error tracing

---

### Steps to Reproduce / Test

---

---

### Checklist

-   [x] PR description included
-   [x] `yarn test` passes
-   [x] Tests are [changed or added]
-   [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

**AuthId removed from response for user during signup**

<img width="1030" alt="Screenshot 2022-04-25 at 6 36 51 PM" src="https://user-images.githubusercontent.com/80456905/165095223-13601efa-c2bf-4594-acef-b0fe17cfa971.png">

**Unique requestId injected to logger for each request**

<img width="986" alt="Screenshot 2022-04-25 at 6 46 18 PM" src="https://user-images.githubusercontent.com/80456905/165096790-c0e1ebb8-7c3c-4b5a-92fd-089fbf63e0cb.png">

---

